### PR TITLE
Make changes in game and user utils to only store one game per user

### DIFF
--- a/src/main/java/com/google/sps/utils/GameUtils.java
+++ b/src/main/java/com/google/sps/utils/GameUtils.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import com.google.appengine.api.datastore.EntityNotFoundException;
 import com.google.appengine.api.datastore.KeyFactory;
 import com.google.appengine.api.datastore.Key;
-import com.google.sps.utils.UserUtils;
 import java.util.logging.Logger;
 
 public final class GameUtils {

--- a/src/main/java/com/google/sps/utils/GameUtils.java
+++ b/src/main/java/com/google/sps/utils/GameUtils.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import com.google.appengine.api.datastore.EntityNotFoundException;
 import com.google.appengine.api.datastore.KeyFactory;
 import com.google.appengine.api.datastore.Key;
+import com.google.sps.utils.UserUtils;
 import java.util.logging.Logger;
 
 public final class GameUtils {
@@ -115,15 +116,6 @@ public final class GameUtils {
     if(userIds == null){
       return false;
     }
- 
-    // create score entity for the user for this game (starts as 0)
-    int score = 0;
-    Entity scoreEntity = new Entity("Score");
-    scoreEntity.setProperty("userId", userId);
-    scoreEntity.setProperty("score", score);
-    String gameId = (String) gameEntity.getProperty("gameId");
-    scoreEntity.setProperty("gameId", gameId);
-    datastore.put(scoreEntity);
  
     // add user to game entity
     userIds.add(userId);

--- a/src/main/java/com/google/sps/utils/UserUtils.java
+++ b/src/main/java/com/google/sps/utils/UserUtils.java
@@ -14,7 +14,6 @@
 
 package com.google.sps.utils;
 
-
 import java.io.*;
 import javax.servlet.*;
 import javax.servlet.http.*;
@@ -84,15 +83,8 @@ public final class UserUtils {
         log.severe("found empty gameId trying to add game to user " + (String) userEntity.getProperty("userId"));
         return false;
     }
- 
-    ArrayList<String> games = (ArrayList<String>) userEntity.getProperty("games");
- 
-    if(games == null){
-        return false;
-    }
- 
-    games.add(gameId);
-    userEntity.setProperty("games", games);
+
+    userEntity.setProperty("gameId", gameId);
     datastore.put(userEntity);
  
     return true;

--- a/src/test/java/com/google/sps/UserUtilTest.java
+++ b/src/test/java/com/google/sps/UserUtilTest.java
@@ -162,8 +162,6 @@ public final class UserUtilTest {
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
     Entity userEntity = new Entity("user");
-    ArrayList<String> gameIds = new ArrayList<>();
-    userEntity.setProperty("games", gameIds);
 
     boolean actual = UserUtils.addGameToUser(userEntity, datastore, "");
 
@@ -175,8 +173,6 @@ public final class UserUtilTest {
   public void addGameToUserNullDatastore() {
 
     Entity userEntity = new Entity("user");
-    ArrayList<String> gameIds = new ArrayList<>();
-    userEntity.setProperty("games", gameIds);
 
     boolean actual = UserUtils.addGameToUser(userEntity, null, "gameId");
 
@@ -192,19 +188,6 @@ public final class UserUtilTest {
 
     Assert.assertEquals(false, actual);
   }
-
-  // test an user entity without a gameid list
-  @Test
-  public void addGameToUserInvalidUser() {
-    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
-
-    Entity userEntity = new Entity("user");
-    userEntity.setProperty("userName", "user1");
-
-    boolean actual = UserUtils.addGameToUser(userEntity, datastore, "gameId");
-
-    Assert.assertEquals(false, actual);
-  }
  
   // test given all correct valid parameters
   @Test
@@ -212,8 +195,6 @@ public final class UserUtilTest {
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
     Entity userEntity = new Entity("user");
-    ArrayList<String> gameIds = new ArrayList<>();
-    userEntity.setProperty("games", gameIds);
 
     boolean actual = UserUtils.addGameToUser(userEntity, datastore, "gameId");
 


### PR DESCRIPTION
Gets rid of score entity assuming score will be stored in the user entity; stores only a single string for game id in user entity instead of an array list of strings; removes test to check if that array list is initialized, since it no longer needs to be. 