### PR TITLE
Add servlets to store and retrieve blobkeys to/from blobstore

### DIFF
--- a/src/main/java/com/google/sps/servlets/UploadHandlerServlet.java
+++ b/src/main/java/com/google/sps/servlets/UploadHandlerServlet.java
@@ -1,0 +1,69 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+ 
+package com.google.sps.servlets;
+ 
+import com.google.appengine.api.blobstore.BlobKey;
+import com.google.appengine.api.blobstore.BlobstoreService;
+import com.google.appengine.api.blobstore.BlobstoreServiceFactory;
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.io.IOException;
+import java.util.List;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import com.google.sps.utils.UserUtils;
+import java.io.*;
+import javax.servlet.*;
+import javax.servlet.http.*; 
+ 
+/** Blobstore upload handler: gets blobkey (Blobstore rewrites the request to contain a blobkey) 
+    for an uploaded image and stores it in datastore 
+    (see https://cloud.google.com/appengine/docs/standard/java/blobstore#3_implement_upload_handler
+    for documentation of an upload handler)
+ */
+@WebServlet("/image-upload-handler-blobstore")
+public class UploadHandlerServlet extends HttpServlet {
+ 
+  BlobstoreService blobstoreService;
+  DatastoreService datastore;
+ 
+  public UploadHandlerServlet(){
+    blobstoreService = BlobstoreServiceFactory.getBlobstoreService();
+    datastore = DatastoreServiceFactory.getDatastoreService();
+  }
+ 
+  // TODO: Limit this so it can only be used as a blobstore upload handler; cut off end-user access
+  @Override
+  public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    
+    // TODO: userID using new func
+    Cookie cookies[] = request.getCookies();
+    Entity userEntity = UserUtils.getUserFromCookie(cookies, datastore);
+    
+    // getting the blobkey + making it part of the request
+    ImmutableMap<String, List<BlobKey>> blobs = ImmutableMap.copyOf(blobstoreService.getUploads(request));
+    ImmutableList<BlobKey> blobKeys = ImmutableList.copyOf(blobs.get("image"));
+    String blobKey = blobKeys.get(0).getKeyString();
+ 
+    UserUtils.addBlobKey(blobKey, userEntity, datastore);
+    
+    response.sendRedirect("/imageUpload.html"); 
+  }
+}

--- a/src/main/java/com/google/sps/servlets/UploadHandlerServlet.java
+++ b/src/main/java/com/google/sps/servlets/UploadHandlerServlet.java
@@ -53,8 +53,12 @@ public class UploadHandlerServlet extends HttpServlet {
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     
-    // TODO: userID using new func
+    // get the user entity 
     Cookie cookies[] = request.getCookies();
+    if(cookies == null){
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        return;
+    }
     Entity userEntity = UserUtils.getUserFromCookie(cookies, datastore);
     
     // getting the blobkey + making it part of the request

--- a/src/main/java/com/google/sps/servlets/UploadHandlerServlet.java
+++ b/src/main/java/com/google/sps/servlets/UploadHandlerServlet.java
@@ -60,6 +60,10 @@ public class UploadHandlerServlet extends HttpServlet {
         return;
     }
     Entity userEntity = UserUtils.getUserFromCookie(cookies, datastore);
+    if(userEntity == null){
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        return;
+    }
     
     // getting the blobkey + making it part of the request
     ImmutableMap<String, List<BlobKey>> blobs = ImmutableMap.copyOf(blobstoreService.getUploads(request));

--- a/src/main/java/com/google/sps/servlets/getBlobKeyServlet.java
+++ b/src/main/java/com/google/sps/servlets/getBlobKeyServlet.java
@@ -1,0 +1,66 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+ 
+package com.google.sps.servlets;
+ 
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query.SortDirection;
+import com.google.gson.Gson;
+import java.io.IOException;
+import java.util.List;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import com.google.appengine.api.datastore.FetchOptions;
+import com.google.sps.utils.UserUtils; 
+import java.io.*;
+import javax.servlet.*;
+import javax.servlet.http.*;
+ 
+/** Retrieves blobkey from Datastore */
+@WebServlet("/get-blob-key")
+public class getBlobKeyServlet extends HttpServlet {
+  
+  DatastoreService datastore;
+ 
+  public getBlobKeyServlet(){
+    datastore = DatastoreServiceFactory.getDatastoreService();
+  }
+ 
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+ 
+    // get user id -- get entity from user id -- new func!!
+    Cookie cookies[] = request.getCookies();
+    Entity userEntity = UserUtils.getUserFromCookie(cookies, datastore);
+ 
+    String blobKey = "noKey";
+    if(userEntity != null){
+      blobKey = (String) userEntity.getProperty("blobKey");
+    }
+    if(blobKey == null){
+        // if the user hasn't uploaded a picture yet, nothing is printed
+        blobKey = "noKey";
+    }
+ 
+    Gson gson = new Gson();
+    response.setContentType("application/json;");
+    response.getWriter().println(gson.toJson(blobKey));
+  }
+} 

--- a/src/main/java/com/google/sps/servlets/getBlobKeyServlet.java
+++ b/src/main/java/com/google/sps/servlets/getBlobKeyServlet.java
@@ -33,7 +33,7 @@ import java.io.*;
 import javax.servlet.*;
 import javax.servlet.http.*;
  
-/** Retrieves blobkey from Datastore */
+/** Retrieves blobkey from Datastore for the image of the logged in user */
 @WebServlet("/get-blob-key")
 public class getBlobKeyServlet extends HttpServlet {
   
@@ -46,8 +46,12 @@ public class getBlobKeyServlet extends HttpServlet {
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
  
-    // get user id -- get entity from user id -- new func!!
+    // get the user entity
     Cookie cookies[] = request.getCookies();
+    if(cookies == null){
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        return;
+    }
     Entity userEntity = UserUtils.getUserFromCookie(cookies, datastore);
  
     String blobKey = "noKey";
@@ -55,8 +59,8 @@ public class getBlobKeyServlet extends HttpServlet {
       blobKey = (String) userEntity.getProperty("blobKey");
     }
     if(blobKey == null){
-        // if the user hasn't uploaded a picture yet, nothing is printed
-        blobKey = "noKey";
+      // if the user hasn't uploaded a picture yet, nothing is printed
+      blobKey = "noKey";
     }
  
     Gson gson = new Gson();

--- a/src/main/java/com/google/sps/servlets/getBlobKeyServlet.java
+++ b/src/main/java/com/google/sps/servlets/getBlobKeyServlet.java
@@ -53,14 +53,16 @@ public class getBlobKeyServlet extends HttpServlet {
         return;
     }
     Entity userEntity = UserUtils.getUserFromCookie(cookies, datastore);
- 
-    String blobKey = "noKey";
-    if(userEntity != null){
-      blobKey = (String) userEntity.getProperty("blobKey");
+    if(userEntity == null){
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        return;
     }
+ 
+    String blobKey = (String) userEntity.getProperty("blobKey");
     if(blobKey == null){
       // if the user hasn't uploaded a picture yet, nothing is printed
-      blobKey = "noKey";
+      response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+      return;
     }
  
     Gson gson = new Gson();


### PR DESCRIPTION
UploadHandlerServlet is revised to use helper functions and get the correct user entity; getBlobKeyServlet gets and returns the stored blobkey so that it can be used to create a url for the image 