### PR TITLE
take out checks to prevent people from joining/starting a new game

### DIFF
--- a/src/main/java/com/google/sps/servlets/joinGameServlet.java
+++ b/src/main/java/com/google/sps/servlets/joinGameServlet.java
@@ -60,12 +60,6 @@ public class joinGameServlet extends HttpServlet {
         return;
     }
 
-    // prevent users from joining more than one game
-    if(userEntity.getProperty("gameId") != null){
-      response.sendRedirect("/gameBoard.html");
-      return;
-    }
-
     Entity gameEntity = UserUtils.getEntityFromDatastore("Game", "gameId", gameId, datastore);
     if(gameEntity == null){
       PrintWriter out = response.getWriter();

--- a/src/main/java/com/google/sps/servlets/startGameServlet.java
+++ b/src/main/java/com/google/sps/servlets/startGameServlet.java
@@ -58,12 +58,6 @@ public class startGameServlet extends HttpServlet {
         return;
     }
  
-    // prevent users from joining more than one game
-    if(userEntity.getProperty("gameId") != null){
-      response.sendRedirect("/gameBoard.html");
-      return;
-    }
- 
     Entity newGame = GameUtils.createGameEntity(gameName, datastore);
     boolean gameSet = GameUtils.setGame(userEntity, datastore, newGame);
  


### PR DESCRIPTION
Instead of redirecting to their current game page when a user tries to join a new game, replace their old game with the new game.