### PR TITLE
fix issue where users without images break the quiz

### DIFF
--- a/src/main/java/com/google/plantasy/servlets/getUserImagesForQuizPage.java
+++ b/src/main/java/com/google/plantasy/servlets/getUserImagesForQuizPage.java
@@ -43,11 +43,9 @@ public class getUserImagesForQuizPage extends HttpServlet {
         for(String player_name : (ArrayList<String>) current_game.getProperty("userIds")) {
             if(!userEntity.getProperty("userID").equals(player_name)) {
                 User player = new User(UserUtils.getEntityFromDatastore("user","userID", player_name, datastore));
-                try {
-                    user_ids_and_pictures.put(player.getName(), player.getBlobKey());
-                } catch (Exception e){
-                    // If player.getBlobKey() causes a NPE, we can skip that user.
-                    continue;
+                String blobkey = player.getBlobKey()
+                if (blobkey != null) {
+                    user_ids_and_pictures.put(player.getName(), blobkey);
                 }
             }
         }

--- a/src/main/java/com/google/plantasy/servlets/getUserImagesForQuizPage.java
+++ b/src/main/java/com/google/plantasy/servlets/getUserImagesForQuizPage.java
@@ -10,6 +10,7 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import com.google.plantasy.utils.QuizTimingPropertiesUtils;
+import com.google.plantasy.utils.User;
 import com.google.plantasy.utils.UserUtils;
 import java.io.*;
 import javax.servlet.*;

--- a/src/main/java/com/google/plantasy/servlets/getUserImagesForQuizPage.java
+++ b/src/main/java/com/google/plantasy/servlets/getUserImagesForQuizPage.java
@@ -39,10 +39,15 @@ public class getUserImagesForQuizPage extends HttpServlet {
         HashMap<String,String> user_ids_and_pictures = new HashMap<String, String>();
 
         Entity current_game = UserUtils.getEntityFromDatastore("Game", "gameId", (userEntity.getProperty("gameId")).toString(), datastore);
-        for(String player : (ArrayList<String>) current_game.getProperty("userIds")) {
-            if(!userEntity.getProperty("userID").equals(player)) {
-                Entity playerEntity = UserUtils.getEntityFromDatastore("user","userID", player, datastore);
-                user_ids_and_pictures.put(player, (playerEntity.getProperty("blobKey")).toString());
+        for(String player_name : (ArrayList<String>) current_game.getProperty("userIds")) {
+            if(!userEntity.getProperty("userID").equals(player_name)) {
+                User player = new User(UserUtils.getEntityFromDatastore("user","userID", player_name, datastore));
+                try {
+                    user_ids_and_pictures.put(player.getName(), player.getBlobKey());
+                } catch (Exception e){
+                    // If player.getBlobKey() causes a NPE, we can skip that user.
+                    continue;
+                }
             }
         }
 


### PR DESCRIPTION
I felt bad breaking the demo so I fixed it

For reference, lines 41 through 52 would have been a good candidate for pulling into a helper function. That way, we could have done proper testing and might have caught the error where a user has no blobkey associated with their entry in the datastore.